### PR TITLE
fix: 引入vue组件时产生call of undefined错误

### DIFF
--- a/src/compiler/webpack/project.js
+++ b/src/compiler/webpack/project.js
@@ -13,9 +13,7 @@ var HappyPack = require('happypack');
 var happyThreadPool = HappyPack.ThreadPool({ size: os.cpus().length });
 
 var FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')
-var ParallelUglifyPlugin = require('webpack-parallel-uglify-plugin');
-
-
+var ParallelUglifyPlugin = require('webpack-parallel-uglify-plugin'); 
 
 var ConfigFactory = require("./base.js");
 
@@ -178,7 +176,8 @@ class ProjectFactory  extends ConfigFactory {
 
         if (options.extract) {
             plugins.push(new ExtractTextPlugin({
-                filename : this._join(this._prefixPath(), filename)
+                filename : this._join(this._prefixPath(), filename),
+                allChunks: true
             }));
         }
         module.rules = rules.concat(cssLoaders);


### PR DESCRIPTION
设置ExtractTextPlugin的allChunks为true, 将所有分离的css样式合成到同一个文件里,
这里并不是彻底解决问题，只是这样做不会引起bug
详情见这里，[https://github.com/webpack/webpack/issues/959](https://github.com/webpack/webpack/issues/959) 
解决方案是根据 @TLDay 的回答更改的。